### PR TITLE
Storage compatible change?

### DIFF
--- a/src/Test.sol
+++ b/src/Test.sol
@@ -5,4 +5,6 @@ import "./Types.sol";
 
 contract Test is Types {
     TokenType public abc;
+
+    bool b;
 }


### PR DESCRIPTION
Diff between the old and the new storage layout (as output by `forge inspect src/Test.sol:Test storage-layout`):

```
9c9,17
<       "type": "t_enum(TokenType)14"
---
>       "type": "t_enum(TokenType)16"
>     },
>     {
>       "astId": 9,
>       "contract": "src/Test.sol:Test",
>       "label": "b",
>       "offset": 1,
>       "slot": "0",
>       "type": "t_bool"
13c21,26
<     "t_enum(TokenType)14": {
---
>     "t_bool": {
>       "encoding": "inplace",
>       "label": "bool",
>       "numberOfBytes": "1"
>     },
>     "t_enum(TokenType)16": {
```

I.e., the unexpected change is the enum type identifier changing from `"t_enum(TokenType)14"` to `"t_enum(TokenType)16"`. I don't know about the details of the Solidity compiler, but the change here doesn't feel like it should break something in the storage, or am I wrong?

To note, if we just move both contract definitions into a single file, for example replace
```
import "./Types.sol";
```
with
```
contract Types {
    enum TokenType {
        ERC20,
        ERC721,
        ERC1155
    }
}
```
the problem doesn't occur, i.e. **the changes are not marked as breaking in this case**.